### PR TITLE
added configuration lines to pom.xml to specify the java version

### DIFF
--- a/cine_source/.classpath
+++ b/cine_source/.classpath
@@ -26,7 +26,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/cine_source/.settings/org.eclipse.core.resources.prefs
+++ b/cine_source/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,6 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/cine_source/.settings/org.eclipse.jdt.core.prefs
+++ b/cine_source/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=17

--- a/cine_source/pom.xml
+++ b/cine_source/pom.xml
@@ -3,6 +3,18 @@
   <groupId>texnologia.logismikou</groupId>
   <artifactId>Cinematrix</artifactId>
   <version>0.0.1-SNAPSHOT</version>
+  <build>
+	<plugins>
+		<plugin>
+        	<artifactId>maven-compiler-plugin</artifactId>
+        	<version>3.11.0</version>
+        	<configuration>
+				<source>17</source>
+				<target>17</target>
+			</configuration>
+		</plugin>
+	</plugins>
+  </build>
   <properties>
 	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
The xml file should now cause no warnings and the build should use the default Java version of Eclipse. closes #42 